### PR TITLE
[#69] Fixed Basic Worktable Crafting for Early Game

### DIFF
--- a/scripts/Mod Specifics/Small Mods/Artisan's Workbench's.zs
+++ b/scripts/Mod Specifics/Small Mods/Artisan's Workbench's.zs
@@ -2,8 +2,8 @@ import mods.artisanworktables.builder.RecipeBuilder;
 
 // Basic Worktable
 recipes.remove(<artisanworktables:worktable:5>);
-recipes.addShaped(<artisanworktables:worktable:5> * 1, [[<ore:plateTreatedWood>, <ore:plateTreatedWood>, <ore:plateTreatedWood>], [<ore:gtceHardHammers>, <gregtech:machine:1647>, <ore:gtceSaws>],[<contenttweaker:searedplate>, null, <contenttweaker:searedplate>]]);
-recipes.addShaped(<artisanworktables:worktable:5> * 1, [[<ore:plateTreatedWood>, <ore:plateTreatedWood>, <ore:plateTreatedWood>], [<ore:gtceSaws>, <gregtech:machine:1647>, <ore:gtceHardHammers>],[<contenttweaker:searedplate>, null, <contenttweaker:searedplate>]]);
+recipes.addShaped(<artisanworktables:worktable:5> * 1, [[<ore:plankTreatedWood>, <ore:plankTreatedWood>, <ore:plankTreatedWood>], [<ore:gtceHardHammers>, <gregtech:machine:1647>, <ore:gtceSaws>],[<contenttweaker:searedplate>, null, <contenttweaker:searedplate>]]);
+recipes.addShaped(<artisanworktables:worktable:5> * 1, [[<ore:plankTreatedWood>, <ore:plankTreatedWood>, <ore:plankTreatedWood>], [<ore:gtceSaws>, <gregtech:machine:1647>, <ore:gtceHardHammers>],[<contenttweaker:searedplate>, null, <contenttweaker:searedplate>]]);
 
 // Blacksmith's Worktable
 recipes.remove(<artisanworktables:worktable:3>);


### PR DESCRIPTION
Changed <ore:plateTreatedWood> into <ore:plankTreatedWood> to make it possible to craft the Basic Worktable without Treated Wood Plates

[Issue #69](https://github.com/ArtpokeBr/Pluma-a-Journey-to-the-Future/issues/69)